### PR TITLE
Fixes Unicode error in ST2

### DIFF
--- a/raw_line_edit.py
+++ b/raw_line_edit.py
@@ -5,6 +5,7 @@ Raw Line Edit
 Licensed under MIT
 Copyright (c) 2013 Isaac Muse <isaacmuse@gmail.com>
 """
+from __future__ import unicode_literals
 import sublime
 import sublime_plugin
 import codecs
@@ -12,7 +13,7 @@ from os.path import basename
 
 import re
 
-new_line = u"¬"
+new_line = "¬"
 
 
 def strip_newline_glyph(text):


### PR DESCRIPTION
ST2 uses Python 2 which requires an explicit UTF-8 encoding and Unicode literals.
